### PR TITLE
Adjust normal orientation calculation

### DIFF
--- a/src/core/hit_record.rs
+++ b/src/core/hit_record.rs
@@ -24,7 +24,7 @@ impl HitRecord {
     }
 
     pub fn set_face_normal(&mut self, r: Ray, outward_normal: Vec3) {
-        self.front_face = dot(r.direction, outward_normal) > 0.0;
+        self.front_face = dot(r.direction, outward_normal) < 0.0;
         self.normal = if self.front_face {
             outward_normal
         } else {

--- a/src/shapes/sphere.rs
+++ b/src/shapes/sphere.rs
@@ -22,19 +22,21 @@ impl Sphere {
 			let temp = (-b - discriminant.sqrt()) / a;
 			if temp < t_max && temp > t_min {
 				rec.t = temp;
-				rec.p = r.at(rec.t);
-				rec.normal = (rec.p - self.center) / self.radius;
-				rec.material = Some(self.material);
-				return true;
+                                rec.p = r.at(rec.t);
+                                let outward_normal = (rec.p - self.center) / self.radius;
+                                rec.set_face_normal(r, outward_normal);
+                                rec.material = Some(self.material);
+                                return true;
 			}
 			
 			let temp = (-b + discriminant.sqrt()) / a;
 			if temp < t_max && temp > t_min {
 				rec.t = temp;
-				rec.p = r.at(rec.t);
-				rec.normal = (rec.p - self.center) / self.radius;
-				rec.material = Some(self.material);
-				return true;
+                                rec.p = r.at(rec.t);
+                                let outward_normal = (rec.p - self.center) / self.radius;
+                                rec.set_face_normal(r, outward_normal);
+                                rec.material = Some(self.material);
+                                return true;
 			}
 		}
 		false


### PR DESCRIPTION
## Summary
- fix orientation check in `HitRecord::set_face_normal`
- compute outward normal for spheres and use `set_face_normal`

## Testing
- `cargo test` *(fails: failed to get `overload` as a dependency)*