### PR TITLE
Clamp color output

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -37,3 +37,13 @@ pub fn random_in_unit_sphere() -> Vec3 {
         }
     }
 }
+
+pub fn clamp(x: f64, min: f64, max: f64) -> f64 {
+    if x < min {
+        min
+    } else if x > max {
+        max
+    } else {
+        x
+    }
+}

--- a/src/core/vec3.rs
+++ b/src/core/vec3.rs
@@ -111,11 +111,15 @@ impl Vec3 {
     }
 
     pub fn print(&self) -> String {
+        let r = super::clamp(self.e[0], 0.0, 0.999);
+        let g = super::clamp(self.e[1], 0.0, 0.999);
+        let b = super::clamp(self.e[2], 0.0, 0.999);
+
         format!(
             "{} {} {}\n",
-            (255.99999 * self.e[0]) as i32,
-            (255.99999 * self.e[1]) as i32,
-            (255.99999 * self.e[2]) as i32
+            (256.0 * r) as i32,
+            (256.0 * g) as i32,
+            (256.0 * b) as i32
         )
     }
 }


### PR DESCRIPTION
## Summary
- clamp each color channel when converting to PPM
- add small `clamp()` helper

## Testing
- `cargo test` *(fails: could not download `overload` crate)*